### PR TITLE
typo in Framework function

### DIFF
--- a/Deconvolution/BLADE.py
+++ b/Deconvolution/BLADE.py
@@ -1194,7 +1194,7 @@ def Framework(X, stdX, Y, Ind_Marker=None, Ind_sample=None,
     print("Done optimization, elapsed time (min): " + str(elapsed/60))
 
     # run on entire cohort
-    if Nsample_small < Nsample or Ngene < Nmarker:
+    if Nsample_small < Nsample or Nmarker < Ngene:
         print("Start inferring per-sample gene expression levels using the entire genes and samples")
 
         logY = np.log(Y+1)


### PR DESCRIPTION
fixed typo in Framework function that was stopping the function from running all of the genes if a subset of marker genes was supplied.